### PR TITLE
Feat: custom mount support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "MicroSDeck"
-        path: release/MicroSDeck/*
+        path: release/MicroSDeck
 
   deploy:
     if: github.ref == 'refs/heads/master'

--- a/backend/src/dto.rs
+++ b/backend/src/dto.rs
@@ -16,6 +16,9 @@ fn default_true() -> bool {
 pub struct MicroSDCard {
 	pub uid: String,
 	pub libid: String,
+	
+	#[serde(default)]
+	pub mount: Option<String>,
 
 	pub name: String,
 	#[serde(default)]

--- a/backend/src/sdcard.rs
+++ b/backend/src/sdcard.rs
@@ -1,9 +1,9 @@
-use std::fs::{self, read_to_string, DirEntry};
+use std::{
+	fs::{self, read_to_string, DirEntry},
+	io,
+};
 
 use crate::err::Error;
-
-pub const STEAM_LIB_FILE: &'static str = "/run/media/mmcblk0p1/libraryfolder.vdf";
-pub const STEAM_LIB_FOLDER: &'static str = "/run/media/mmcblk0p1/steamapps/";
 
 pub fn is_card_inserted() -> bool {
 	std::fs::metadata("/sys/block/mmcblk0").is_ok()
@@ -16,13 +16,29 @@ pub fn get_card_cid() -> Option<String> {
 		.ok()
 }
 
-pub fn is_card_steam_formatted() -> bool {
-	std::fs::metadata("/run/media/mmcblk0p1/libraryfolder.vdf").is_ok()
+pub fn has_libraryfolder(mount: &Option<String>) -> bool {
+	std::fs::metadata(format!(
+		"/run/media/{}/libraryfolder.vdf",
+		mount.clone().unwrap_or("mmcblk0p1".into())
+	))
+	.is_ok()
 }
 
-pub fn get_steam_acf_files() -> Result<impl Iterator<Item = DirEntry>, Error> {
-	Ok(fs::read_dir(STEAM_LIB_FOLDER)?
-		.into_iter()
-		.filter_map(Result::ok)
-		.filter(|f| f.path().extension().unwrap_or_default().eq("acf")))
+pub fn read_libraryfolder(mount: &Option<String>) -> io::Result<String> {
+	std::fs::read_to_string(format!(
+		"/run/media/{}/libraryfolder.vdf",
+		mount.clone().unwrap_or("mmcblk0p1".into())
+	))
+}
+
+pub fn get_steam_acf_files(
+	mount: &Option<String>,
+) -> Result<impl Iterator<Item = DirEntry>, Error> {
+	Ok(fs::read_dir(format!(
+		"/run/media/{}/steamapps/",
+		mount.clone().unwrap_or("mmcblk0p1".into())
+	))?
+	.into_iter()
+	.filter_map(Result::ok)
+	.filter(|f| f.path().extension().unwrap_or_default().eq("acf")))
 }

--- a/lib/src/backend.ts
+++ b/lib/src/backend.ts
@@ -32,7 +32,7 @@ async function wrapFetch({ url, logger }: FetchProps, init?: RequestInit): Promi
 	return undefined;
 }
 
-export async function fetchEventPoll({ url, logger, signal }: FetchProps & { signal: AbortSignal }): Promise<string | boolean | undefined> {
+export async function fetchEventPoll({ url, logger, signal }: FetchProps & { signal: AbortSignal }): Promise<string | false | undefined> {
 	try {
 		const result = await fetch(`${url}/listen`, {
 			keepalive: true,


### PR DESCRIPTION
If a MicroSD card has been labelled it will be mounted to the directory that the label matches. Since this differs from the expected directory of `mmcblk0` we need to identify which mount directory the card uses and use that for future scanning of this card. 