### PR TITLE
Support capital or lowercase universe key in acf

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "once_cell",
  "semver",
  "serde",
+ "serde_alias",
  "serde_json",
  "simplelog",
  "slotmap",
@@ -1248,6 +1249,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1430,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_alias"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be4d78e3674912678d7c86b8c507fa72ebff66a8dd3359dc54ec97164b68474"
+dependencies = [
+ "convert_case",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,6 +15,7 @@ simplelog = "0.12"
 once_cell = "1.18.0"
 chrono = "0.4.24"
 serde_json = "1.0"
+serde_alias = "0.0.2"
 tokio = { version = "1.26.0", features = ["full"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 futures = "0.3.26"

--- a/backend/src/steam.rs
+++ b/backend/src/steam.rs
@@ -11,6 +11,7 @@ pub struct LibraryFolder {
 #[derive(Deserialize)]
 pub struct AppState {
 	pub appid: String,
+	#[serde(alias = "Universe")]
 	pub universe: i32,
 	pub name: String,
 	#[serde(rename(deserialize = "StateFlags"))]

--- a/backend/src/steam.rs
+++ b/backend/src/steam.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display};
 
 use serde::Deserialize;
+use serde_alias::serde_alias;
 
 #[derive(Deserialize, Debug)]
 pub struct LibraryFolder {
@@ -8,16 +9,19 @@ pub struct LibraryFolder {
 	pub label: String,
 }
 
+#[serde_alias(
+	CamelCase,
+	PascalCase,
+	LowerCase,
+	SnakeCase
+)]
 #[derive(Deserialize)]
 pub struct AppState {
 	pub appid: String,
-	#[serde(alias = "Universe")]
 	pub universe: i32,
 	pub name: String,
-	#[serde(rename(deserialize = "StateFlags"))]
 	pub state_flags: Option<i32>,
 	pub installdir: String,
-	#[serde(rename(deserialize = "SizeOnDisk"))]
 	pub size_on_disk: u64,
 }
 


### PR DESCRIPTION
When I first tried out this plugin I did some debugging and hand-patched the plugin to support capital "universe" key name in the ACF files. I wrote this patch but didn't really get a chance to test a build until this week, sorry!

I think this might solve remaining issues with #9 at least for those people who have SD cards that ARE recognized but think there are zero games installed.

I compared the ACF files for one game from my Windows Steam library and the Deck and found the keyname difference there:
# ACF Files
## Windows ACF File
```
"AppState"
{
	"appid"		"1337520"
	"universe"		"1"
	"name"		"Risk of Rain Returns"
	"StateFlags"		"4"
	"installdir"		"Risk of Rain Returns"
	"lastupdated"		"1705742620"
	"SizeOnDisk"		"521429440"
	"StagingSize"		"0"
	"buildid"		"13005567"
	"LastOwner"		"76561198058929440"
	"AutoUpdateBehavior"		"0"
	"AllowOtherDownloadsWhileRunning"		"0"
	"ScheduledAutoUpdate"		"0"
	"InstalledDepots"
	{
		"1337521"
		{
			"manifest"		"2126128840766829407"
			"size"		"521429440"
		}
	}
	"UserConfig"
	{
		"language"		"english"
	}
	"MountedConfig"
	{
		"language"		"english"
	}
}
```
## Deck ACF File
```
"AppState"
{
	"appid"		"1337520"
	"Universe"		"1"
	"name"		"Risk of Rain Returns"
	"StateFlags"		"4"
	"installdir"		"Risk of Rain Returns"
	"lastupdated"		"1705057781"
	"SizeOnDisk"		"521429440"
	"StagingSize"		"0"
	"buildid"		"13005567"
	"LastOwner"		"76561198058929440"
	"AutoUpdateBehavior"		"0"
	"AllowOtherDownloadsWhileRunning"		"0"
	"ScheduledAutoUpdate"		"0"
	"InstalledDepots"
	{
		"1337521"
		{
			"manifest"		"2126128840766829407"
			"size"		"521429440"
		}
	}
	"UserConfig"
	{
		"language"		"english"
	}
	"MountedConfig"
	{
		"language"		"english"
	}
}
```
# Fix and Testing 
I found the serde docs and noted that it was possible to set key aliases with a simple decorator on the deserialization for the key `#[serde(alias = "Universe")]`

- [x] This fixes the game recognition on my Deck where the keys are capital "U". 
- [ ] Still need to test on a Deck with the lowercase "u"

---
For completeness, I tested this issue on a Deck OLED with OS Update Channel Stable (3.5.7) and Steam Client Update Stable (1705108172 from 12 Jan).
PS: sorry about the crap branchname. I didn't realize Github would name it "patch-1" and I didn't have my IDE at the time XD