### PR TITLE
bugfix: fixed automatic deletion of non steam games

### DIFF
--- a/backend/src/watch.rs
+++ b/backend/src/watch.rs
@@ -38,7 +38,7 @@ fn read_msd_directory(datastore: &Store, mount: &Option<String>) -> Result<(), E
 	let current_games = datastore.get_games_on_card(&cid)?;
 	for deleted_game in current_games
 		.iter()
-		.filter(|v| !games.iter().any(|g| g.appid == v.uid))
+		.filter(|v| v.is_steam && !games.iter().any(|g| g.appid == v.uid))
 	{
 		datastore.unlink(&deleted_game.uid, &cid)?
 	}


### PR DESCRIPTION
It seems I was especially daft & forgot to exclude non steam games from getting deleted. Well here is the fix. Enjoy ❤️