### PR TITLE
Change the build-docker.sh file to return exit code from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Download Decky CLI
       run: |
         mkdir /tmp/decky-cli
-        curl -L -o /tmp/decky-cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/download/0.0.1-alpha.12/decky"
+        curl -L -o /tmp/decky-cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/download/0.0.2/decky-linux-x86_64"
         chmod +x /tmp/decky-cli/decky
 
         echo "/tmp/decky-cli" >> $GITHUB_PATH

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,4 @@ FROM ghcr.io/steamdeckhomebrew/holo-toolchain-rust:latest
 
 RUN pacman -S --noconfirm cmake make clang git
 
-# Updates the Crates.io index
-RUN cargo search --limit 0
-
 ENTRYPOINT [ "/backend/entrypoint.sh" ]

--- a/backend/build-docker.sh
+++ b/backend/build-docker.sh
@@ -9,6 +9,7 @@ mkdir -p out
 
 echo "--- Building plugin backend ---"
 cargo build --profile docker
+BUILD_EXIT=$?
 mkdir -p out
 
 mv target/docker/backend out/backend
@@ -18,3 +19,4 @@ echo " --- Cleaning up ---"
 cargo clean
 # remove newly-cloned git repo and artifacts
 rm -rf ./ryzenadj
+exit $BUILD_EXIT


### PR DESCRIPTION
According to https://github.com/rust-lang/cargo/issues/3377#issuecomment-417950125 the cargo search doesn't update the index and later in the thread is pointed out this is unnecessary now. Which is good because this doesn't work anymore, and with the CLI changes will actually stop the build when it throws the error.

