### PR TITLE
Updated Build to include version on decky publish (fixes 0.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
 	"author": "Christopher-Robin <git@cebbinghaus.com>",
 	"license": "GPL-2.0",
 	"scripts": {
+		"prebuild": "exec node --no-warnings=ExperimentalWarning util/versioning.mjs update",
 		"build": "shx rm -rf dist && rollup -c",
+		"bundle": "shx rm -rf dist && rollup -c",
 		"watch": "rollup -c -w",
 		"preinstall": "cd lib && pnpm i"
 	},

--- a/util/build.mjs
+++ b/util/build.mjs
@@ -52,7 +52,7 @@ if (!process.argv.includes('--skip-frontend')) {
 	}
 
 	Logger.Log('Building frontend');
-	runCommand('pnpm run build');
+	runCommand('pnpm run bundle');
 }
 
 if (!process.argv.includes('--skip-collect')) {


### PR DESCRIPTION
I had completely neglected to realize that Decky builds using its own CLI and does not in fact invoke my build script. So now a plain npm build will also update all the version numbers to stay in sync.