### PR TITLE
bugfix: Fix Backend CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Download Decky CLI
       run: |
         mkdir /tmp/decky-cli
-        curl -L -o /tmp/decky-cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/download/0.0.2/decky-linux-x86_64"
+        curl -L -o /tmp/decky-cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-linux-x86_64"
         chmod +x /tmp/decky-cli/decky
 
         echo "/tmp/decky-cli" >> $GITHUB_PATH

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/steamdeckhomebrew/holo-toolchain-rust@sha256:d071cc098dd45b7ab3564ab91b13e809f7020bd6bf8e9166cfaef55401ccd776
+FROM ghcr.io/steamdeckhomebrew/holo-toolchain-rust:latest
 
 RUN pacman -S --noconfirm cmake make clang git
 


### PR DESCRIPTION
Currently the Backend CI is pinned to a particular container version since it fails to run properly with the new container. This could be due to the decky cli which this change updates to the latest version.